### PR TITLE
Preserve TLS info and log it

### DIFF
--- a/forward/fwd.go
+++ b/forward/fwd.go
@@ -91,8 +91,17 @@ func (f *Forwarder) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	f.log.Infof("Got response from %v, code: %v, duration: %v",
-		req.URL, response.StatusCode, time.Now().UTC().Sub(start))
+	if req.TLS != nil {
+		f.log.Infof("Round trip: %v, code: %v, duration: %v tls:version: %x, tls:resume:%t, tls:csuite:%x, tls:server:%v",
+			req.URL, response.StatusCode, time.Now().UTC().Sub(start),
+			req.TLS.Version,
+			req.TLS.DidResume,
+			req.TLS.CipherSuite,
+			req.TLS.ServerName)
+	} else {
+		f.log.Infof("Round trip: %v, code: %v, duration: %v",
+			req.URL, response.StatusCode, time.Now().UTC().Sub(start))
+	}
 
 	utils.CopyHeaders(w.Header(), response.Header)
 	w.WriteHeader(response.StatusCode)

--- a/forward/fwd_test.go
+++ b/forward/fwd_test.go
@@ -233,7 +233,10 @@ func (s *FwdSuite) TestForwardedProto(c *C) {
 	})
 	defer srv.Close()
 
-	f, err := New()
+	buf := &bytes.Buffer{}
+	l := utils.NewFileLogger(buf, utils.INFO)
+
+	f, err := New(Logger(l))
 	c.Assert(err, IsNil)
 
 	proxy := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -248,6 +251,8 @@ func (s *FwdSuite) TestForwardedProto(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(re.StatusCode, Equals, http.StatusOK)
 	c.Assert(proto, Equals, "https")
+
+	c.Assert(strings.Contains(buf.String(), "tls"), Equals, true)
 }
 
 func (s *FwdSuite) TestChunkedResponseConversion(c *C) {

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -285,8 +285,6 @@ func (s *Streamer) copyRequest(req *http.Request, body io.ReadCloser, bodySize i
 	o.TransferEncoding = []string{}
 	// http.Transport will close the request body on any error, we are controlling the close process ourselves, so we override the closer here
 	o.Body = ioutil.NopCloser(body)
-	// Preserve TLS state if it's present
-	o.TLS = req.TLS
 	return &o
 }
 

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -285,6 +285,8 @@ func (s *Streamer) copyRequest(req *http.Request, body io.ReadCloser, bodySize i
 	o.TransferEncoding = []string{}
 	// http.Transport will close the request body on any error, we are controlling the close process ourselves, so we override the closer here
 	o.Body = ioutil.NopCloser(body)
+	// Preserve TLS state if it's present
+	o.TLS = req.TLS
 	return &o
 }
 

--- a/stream/stream_test.go
+++ b/stream/stream_test.go
@@ -2,6 +2,7 @@ package stream
 
 import (
 	"bufio"
+	"crypto/tls"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -293,4 +294,39 @@ func (s *STSuite) TestNoBody(c *C) {
 	re, _, err := testutils.Get(proxy.URL)
 	c.Assert(err, IsNil)
 	c.Assert(re.StatusCode, Equals, http.StatusOK)
+}
+
+// Make sure that stream handler preserves TLS settings
+func (s *STSuite) TestPreservesTLS(c *C) {
+	srv := testutils.NewHandler(func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	})
+	defer srv.Close()
+
+	// forwarder will proxy the request to whatever destination
+	fwd, err := forward.New()
+	c.Assert(err, IsNil)
+
+	var t *tls.ConnectionState
+	// this is our redirect to server
+	rdr := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		t = req.TLS
+		req.URL = testutils.ParseURI(srv.URL)
+		fwd.ServeHTTP(w, req)
+	})
+
+	// stream handler will forward requests to redirect
+	st, err := New(rdr, Logger(utils.NewFileLogger(os.Stdout, utils.INFO)))
+	c.Assert(err, IsNil)
+
+	proxy := httptest.NewUnstartedServer(st)
+	proxy.StartTLS()
+	defer proxy.Close()
+
+	re, _, err := testutils.Get(proxy.URL)
+	c.Assert(err, IsNil)
+	c.Assert(re.StatusCode, Equals, http.StatusOK)
+
+	c.Assert(t, NotNil)
 }


### PR DESCRIPTION
**Purpose**

Make sure we are not losing TLS info state when copying requests

**Implementation**

* When copying over `http.Request` copy over `TLS` field as well. `TLS` field contains TLS connection state information.