### PR TITLE
Pass Host Header on proxied requests.

### DIFF
--- a/forward/fwd.go
+++ b/forward/fwd.go
@@ -122,6 +122,8 @@ func (f *Forwarder) copyRequest(req *http.Request, u *url.URL) *http.Request {
 	outReq.URL.Opaque = req.RequestURI
 	// raw query is already included in RequestURI, so ignore it to avoid dupes
 	outReq.URL.RawQuery = ""
+	// Go doesn't implicitly pass the host header unless you set Host on the request
+	outReq.Host = u.Host
 
 	outReq.Proto = "HTTP/1.1"
 	outReq.ProtoMajor = 1


### PR DESCRIPTION
Go doesn't implicitly pass the `Host` header when making requests though the `http` library. Services like Heroku depend on the `Host` header based routing. Set `req.Host` so that the host header is sent for each request.