### PR TITLE
If forwarded headers are trusted - don't mangle X-Forwarded-Host

### DIFF
--- a/forward/fwd_test.go
+++ b/forward/fwd_test.go
@@ -115,6 +115,7 @@ func (s *FwdSuite) TestForwardedHeaders(c *C) {
 		XForwardedProto:  []string{"httpx"},
 		XForwardedFor:    []string{"192.168.1.1"},
 		XForwardedServer: []string{"foobar"},
+		XForwardedHost:   []string{"upstream-foobar"},
 	}
 
 	re, _, err := testutils.Get(proxy.URL, testutils.Headers(headers))
@@ -122,6 +123,7 @@ func (s *FwdSuite) TestForwardedHeaders(c *C) {
 	c.Assert(re.StatusCode, Equals, http.StatusOK)
 	c.Assert(outHeaders.Get(XForwardedProto), Equals, "httpx")
 	c.Assert(strings.Contains(outHeaders.Get(XForwardedFor), "192.168.1.1"), Equals, true)
+	c.Assert(strings.Contains(outHeaders.Get(XForwardedHost), "upstream-foobar"), Equals, true)
 	c.Assert(outHeaders.Get(XForwardedServer), Equals, "hello")
 }
 

--- a/forward/rewrite.go
+++ b/forward/rewrite.go
@@ -32,9 +32,12 @@ func (rw *HeaderRewriter) Rewrite(req *http.Request) {
 		req.Header.Set(XForwardedProto, "http")
 	}
 
-	if req.Host != "" {
+	if xfh := req.Header.Get(XForwardedHost); xfh != "" && rw.TrustForwardHeader {
+		req.Header.Set(XForwardedHost, xfh)
+	} else if req.Host != "" {
 		req.Header.Set(XForwardedHost, req.Host)
 	}
+
 	if rw.Hostname != "" {
 		req.Header.Set(XForwardedServer, rw.Hostname)
 	}


### PR DESCRIPTION
When setting `TrustForwardHeader`, I would expect `X-Forwarded-Host` to be forwarded to my application.

