### PR TITLE
Use parameter for the PassHostHeader optSetter

### DIFF
--- a/forward/fwd.go
+++ b/forward/fwd.go
@@ -20,9 +20,9 @@ type ReqRewriter interface {
 
 type optSetter func(f *Forwarder) error
 
-func PassHostHeader(bool) optSetter {
+func PassHostHeader(b bool) optSetter {
 	return func(f *Forwarder) error {
-		f.passHost = true
+		f.passHost = b
 		return nil
 	}
 }


### PR DESCRIPTION
This change is to ensure the parameter passed into PassHostHeader is what is used to set the behavior.

This is to ensure explicit enablement/disablement work as expected, and f.passHost isn't set to true asymptotically.